### PR TITLE
Add support for scopeTag and scopeBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,13 @@ npx date-based-version
 
 # on a release branch
 npx date-based-version --patch
+
+# dry run (won't create branch or tag)
+npx date-based-version --dry-run
+
+# scope tag by prefix (i.e. scope/v1.20200510.1.0)
+npx date-based-version --scopeTag=scope
+
+# scope branch by prefix (i.e. scope/release/v1.20200510.1)
+npx date-based-version --scopeBranch=scope
 ```

--- a/bin/setVersion.js
+++ b/bin/setVersion.js
@@ -3,9 +3,21 @@
 const dryRun = process.argv.includes("--dry-run");
 const patch = process.argv.includes("--patch");
 
+const scopeTagArg = process.argv.find((arg) => arg.startsWith("--scopeTag"));
+const scopeTag = scopeTagArg ? scopeTagArg.split("=").pop() : undefined;
+
+const scopeBranchArg = process.argv.find((arg) =>
+  arg.startsWith("--scopeBranch")
+);
+const scopeBranch = scopeBranchArg
+  ? scopeBranchArg.split("=").pop()
+  : undefined;
+
 const version = require("../index").setVersion({
   cwd: process.cwd(),
   dryRun,
   patch,
+  scopeTag,
+  scopeBranch,
 });
 console.log(version);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/VincentBailly/date-based-version"
   },
-  "version": "2.3.1",
+  "version": "2.4.0",
   "bin": {
     "date-base-version": "./bin/setVersion.js"
   },

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -7,10 +7,24 @@ type ReleaseBranch = {
   toString: () => string;
 };
 
-export function toReleaseBranch(version: Version): ReleaseBranch {
-  return makeReleaseBranch(version.p1, version.p2, version.p3);
+export function toReleaseBranch(
+  version: Version,
+  scopeBranch?: string
+): ReleaseBranch {
+  return makeReleaseBranch(version.p1, version.p2, version.p3, scopeBranch);
 }
 
-function makeReleaseBranch(p1: number, p2: number, p3: number): ReleaseBranch {
-  return { p1, p2, p3, toString: () => `release/v${p1}.${p2}.${p3}` };
+function makeReleaseBranch(
+  p1: number,
+  p2: number,
+  p3: number,
+  scopeBranch?: string
+): ReleaseBranch {
+  return {
+    p1,
+    p2,
+    p3,
+    toString: () =>
+      `${scopeBranch ? `${scopeBranch}/` : ``}release/v${p1}.${p2}.${p3}`,
+  };
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,14 +3,14 @@ import { writeFileSync } from "fs";
 import { join } from "path";
 import { commandSync } from "execa";
 
-export function getCurrentBranch(cwd): string {
+export function getCurrentBranch(cwd: string): string {
   return readFileSync(join(cwd, ".git", "HEAD"))
     .toString()
     .trim()
     .replace("ref: refs/heads/", "");
 }
 
-export function getTags(cwd): string[][] {
+export function getTags(cwd: string): string[][] {
   const gitLogOutput = commandSync("git log --format='%D'", {
     cwd,
   }).stdout.toString();
@@ -34,7 +34,7 @@ export function checkoutNewBranch(branchName: string, cwd: string): void {
   commandSync(`git checkout -b ${branchName}`, { cwd });
 }
 
-export function createCommit(cwd): void {
+export function createCommit(cwd: string): void {
   const randomString = Math.random().toString();
   writeFileSync(join(cwd, `${randomString}.txt`), randomString);
   commandSync(`git add ${randomString}.txt`, { cwd });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,14 @@ export function setVersion(options: {
   cwd: string;
   dryRun?: boolean;
   patch?: boolean;
+  scopeTag?: string;
+  scopeBranch?: string;
 }): string {
-  const { cwd } = options;
+  const { cwd, scopeTag, scopeBranch } = options;
   const dryRun = options.dryRun || false;
   const patch = options.patch || false;
 
-  const latestVersion = tryGetLatestVersion(cwd);
+  const latestVersion = tryGetLatestVersion(cwd, scopeTag);
 
   if (!patch) {
     const currentLatestVersionFromToday = isVersionFromToday(latestVersion)
@@ -27,12 +29,12 @@ export function setVersion(options: {
     const newVersion = bumpMinor(currentLatestVersionFromToday);
 
     if (dryRun) {
-      console.log(`git tag ${newVersion.getTag()}`);
+      console.log(`git tag ${newVersion.getTag(scopeTag)}`);
     } else {
-      tag(newVersion.getTag(), cwd);
+      tag(newVersion.getTag(scopeTag), cwd);
     }
 
-    const newBranch = toReleaseBranch(newVersion);
+    const newBranch = toReleaseBranch(newVersion, scopeBranch);
     if (dryRun) {
       console.log(`git checkout -b ${newBranch.toString()}`);
     } else {
@@ -48,9 +50,9 @@ export function setVersion(options: {
 
     const newVersion = bumpPatch(latestVersion);
     if (dryRun) {
-      console.log(`git tag ${newVersion.getTag()}`);
+      console.log(`git tag ${newVersion.getTag(scopeTag)}`);
     } else {
-      tag(newVersion.getTag(), cwd);
+      tag(newVersion.getTag(scopeTag), cwd);
     }
     return newVersion.getVersion();
   }


### PR DESCRIPTION
Add support for the flags `--scopeTag` and `--scopeBranch`.

```
# scope tag by prefix (i.e. scope/v1.20200510.1.0)
npx date-based-version --scopeTag=scope

# scope branch by prefix (i.e. scope/release/v1.20200510.1)
npx date-based-version --scopeBranch=scope
```