### PR TITLE
Enabling sub-scope for patching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Call this function from the release pipeline.
 - The new version will be calculated based on the previous version, the date and the patch flag.
 - The commit will be tagged with the version.
 - If the --patch flag is not provided, a release branch will be created.
+- The --iterateOnScope can be used in a patching scenario and it needs to be paired with the --scopeTag argument. This is particularly useful in a monorepo where you would wand to maintain multiple scope. Example your release pipeline produces the following tag: `release/v1.YearMonthDay.version` and you wish to patch a package using a different tag pattern. You can achieve this by calling `npx date-based-version --patch --scopedBranch=release/<package> --iterateOnScope` and you will get the following tag: `release/<package>/v1.YearMonthDay.version.patch`.
 
 ```
 # on master

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Call this function from the release pipeline.
 - The new version will be calculated based on the previous version, the date and the patch flag.
 - The commit will be tagged with the version.
 - If the --patch flag is not provided, a release branch will be created.
-- The --iterateOnScope can be used in a patching scenario and it needs to be paired with the --scopeTag argument. This is particularly useful in a monorepo where you would wand to maintain multiple scope. Example your release pipeline produces the following tag: `release/v1.YearMonthDay.version` and you wish to patch a package using a different tag pattern. You can achieve this by calling `npx date-based-version --patch --scopedBranch=release/<package> --iterateOnScope` and you will get the following tag: `release/<package>/v1.YearMonthDay.version.patch`.
+- When you provide a scope through the --scopeTag argument. It will iterate through all the sub scope until it finds a matching tag. This is particularly useful in a monorepo where you would wand to maintain multiple scope. Example your release pipeline produces the following tag: `release/v1.YearMonthDay.version` and you wish to patch a package using a different tag pattern. You can achieve this by calling `npx date-based-version --patch --scopedBranch=release/<team> --iterateOnScope` and you will get the following tag: `release/<team>/v1.YearMonthDay.version.patch`.
 
 ```
 # on master

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -362,10 +362,6 @@ describe("Scope branch", () => {
 describe("when patching with iterateOnScope set to true", () => {
   it("The first commit to patch a scope needs to find the newest sub scope", () => {
     // Setup
-    jest
-      .spyOn(global.Date, "now")
-      .mockImplementation(() => new Date("2023-12-12T10:01:58.135Z").valueOf());
-
     const cwd = createNewRepo();
 
     createCommit(cwd);
@@ -381,10 +377,6 @@ describe("when patching with iterateOnScope set to true", () => {
 
   it("All the non-first commits to patch a scope needs should use iterate on their respective scope", () => {
     // Setup
-    jest
-      .spyOn(global.Date, "now")
-      .mockImplementation(() => new Date("2023-12-12T10:01:58.135Z").valueOf());
-
     const cwd = createNewRepo();
 
     createCommit(cwd);

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -369,7 +369,7 @@ describe("when patching with iterateOnScope set to true", () => {
     const scopeTag = "scope/package";
 
     //Act
-    setVersion({ cwd, scopeTag, patch: true, iterateOnScope: true });
+    setVersion({ cwd, scopeTag, patch: true });
 
     const tags = getTags(cwd);
     expect(tags[0]).toContain("scope/package/v1.20231211.1.1");
@@ -381,11 +381,12 @@ describe("when patching with iterateOnScope set to true", () => {
 
     createCommit(cwd);
     tag(`scope/v1.20231211.1.0`, cwd);
+    createCommit(cwd);
     tag(`scope/package/v1.20231211.1.1`, cwd);
     const scopeTag = "scope/package";
 
     //Act
-    setVersion({ cwd, scopeTag, patch: true, iterateOnScope: true });
+    setVersion({ cwd, scopeTag, patch: true });
 
     const tags = getTags(cwd);
     expect(tags[0]).toContain("scope/package/v1.20231211.1.2");

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -358,3 +358,44 @@ describe("Scope branch", () => {
     expect(currenBranch).toBe("release/v1.20200510.3");
   });
 });
+
+describe("when patching with iterateOnScope set to true", () => {
+  it("The first commit to patch a scope needs to find the newest sub scope", () => {
+    // Setup
+    jest
+      .spyOn(global.Date, "now")
+      .mockImplementation(() => new Date("2023-12-12T10:01:58.135Z").valueOf());
+
+    const cwd = createNewRepo();
+
+    createCommit(cwd);
+    tag(`scope/v1.20231211.1.0`, cwd);
+    const scopeTag = "scope/package";
+
+    //Act
+    setVersion({ cwd, scopeTag, patch: true, iterateOnScope: true });
+
+    const tags = getTags(cwd);
+    expect(tags[0]).toContain("scope/package/v1.20231211.1.1");
+  });
+
+  it("All the non-first commits to patch a scope needs should use iterate on their respective scope", () => {
+    // Setup
+    jest
+      .spyOn(global.Date, "now")
+      .mockImplementation(() => new Date("2023-12-12T10:01:58.135Z").valueOf());
+
+    const cwd = createNewRepo();
+
+    createCommit(cwd);
+    tag(`scope/v1.20231211.1.0`, cwd);
+    tag(`scope/package/v1.20231211.1.1`, cwd);
+    const scopeTag = "scope/package";
+
+    //Act
+    setVersion({ cwd, scopeTag, patch: true, iterateOnScope: true });
+
+    const tags = getTags(cwd);
+    expect(tags[0]).toContain("scope/package/v1.20231211.1.2");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,10 @@ export function setVersion(options: {
   patch?: boolean;
   scopeTag?: string;
   scopeBranch?: string;
-  iterateOnScope?: boolean;
 }): string {
   const { cwd, scopeTag, scopeBranch } = options;
   const dryRun = options.dryRun || false;
   const patch = options.patch || false;
-  const iterateOnScope = options.iterateOnScope || false;
 
   let latestVersion = tryGetLatestVersion(cwd, scopeTag);
 
@@ -44,7 +42,7 @@ export function setVersion(options: {
     }
     return newVersion.getVersion();
   } else {
-    if (!latestVersion && scopeTag && iterateOnScope) {
+    if (!latestVersion && scopeTag) {
       let subScope = getSubScope(scopeTag);
       while (!latestVersion && subScope) {
         latestVersion = tryGetLatestVersion(cwd, subScope);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,10 @@ export function setVersion(options: {
     return newVersion.getVersion();
   } else {
     if (!latestVersion && scopeTag && iterateOnScope) {
-      let subScope = scopeTag.split("/").slice(0, -1).join("/");
+      let subScope = getSubScope(scopeTag);
       while (!latestVersion && subScope) {
         latestVersion = tryGetLatestVersion(cwd, subScope);
-        subScope = subScope.split("/").slice(0, -1).join("/");
+        subScope = getSubScope(subScope);
       }
     }
     if (!latestVersion) {
@@ -65,4 +65,8 @@ export function setVersion(options: {
     }
     return newVersion.getVersion();
   }
+}
+
+function getSubScope(scope: string): string {
+  return scope.split("/").slice(0, -1).join("/");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,14 @@ export function setVersion(options: {
   patch?: boolean;
   scopeTag?: string;
   scopeBranch?: string;
+  iterateOnScope?: boolean;
 }): string {
   const { cwd, scopeTag, scopeBranch } = options;
   const dryRun = options.dryRun || false;
   const patch = options.patch || false;
+  const iterateOnScope = options.iterateOnScope || false;
 
-  const latestVersion = tryGetLatestVersion(cwd, scopeTag);
+  let latestVersion = tryGetLatestVersion(cwd, scopeTag);
 
   if (!patch) {
     const currentLatestVersionFromToday = isVersionFromToday(latestVersion)
@@ -42,6 +44,13 @@ export function setVersion(options: {
     }
     return newVersion.getVersion();
   } else {
+    if (!latestVersion && scopeTag && iterateOnScope) {
+      let subScope = scopeTag.split("/").slice(0, -1).join("/");
+      while (!latestVersion && subScope) {
+        latestVersion = tryGetLatestVersion(cwd, subScope);
+        subScope = subScope.split("/").slice(0, -1).join("/");
+      }
+    }
     if (!latestVersion) {
       throw new Error(
         "The current branch does not have any version tag in its history"


### PR DESCRIPTION
In a monorepo scenario, a case could be made that you want to release your packages with a generic tag (e.g. `release/v1.20231212.1.0`), however once comes the time for patching, you might want to use more specific tags and perhaps include a package name into the tag (e.g. `release/<package>/v1.20231212.1.1`). This PR allows to do that.

Using the examples above, when a first patch is made using a patch scope, the latest tag on your branch would be something similar to this : `release/v1.20231212.1.0`, but your goal is create a tag as follow: `release/<package>/v1.2023.1212.1.0`. If no match is found for the `release/<package>/` pattern, it will iterate through the scope until it finds a matching tag for the sub-scope. In this case it would match for `release/`. 

Alternatively, if it's the second patch for a given patch scope, this means that your branch will have a tag `release/<package>/*` as it's latest tag and it would match this one instead.