### PR TITLE
fix unit test for new versions of git

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -236,7 +236,7 @@ describe("When it is a patch build", () => {
     tag(`v1.20200512.2.0`, cwd);
     checkoutNewBranch(`release/v1.20200512.2`, cwd);
 
-    commandSync("git checkout master", { cwd });
+    commandSync("git checkout main", { cwd });
     createCommit(cwd);
     tag(`v1.20200512.3.0`, cwd);
 


### PR DESCRIPTION
A unit test used the "master" branch as the main branch and this does not work with recent git setups.